### PR TITLE
Add sometype of report back on CD status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
 
   environment {
     SIDEKIQ_PRO_SECRET = credentials("sidekiq_pro_secret")
+    SLACK_WEBHOOK_URL = credentials("access_slack_webhook")
   }
 
   stages {
@@ -28,6 +29,13 @@ pipeline {
 
           # Deploy it
           bundle exec cap stage deploy
+          
+          if [ $? = 0 ]; then
+            status = "The deploy to stage was successful"
+          else
+            status = "The deploy to stage was unsuccessful"
+          fi
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"$status"}' $SLACK_WEBHOOK_URL
           '''
         }
       }


### PR DESCRIPTION
I'm not sure really how to test this in advance, but the credentials were added and I was able to successfully curl some things from the ci machine.