### PR TITLE
Style Share modal a bit

### DIFF
--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -1,0 +1,4 @@
+.share-modal .embed-textarea {
+   height: 94px;
+   width: 100%;
+}

--- a/app/javascript/components/ShareModal.js
+++ b/app/javascript/components/ShareModal.js
@@ -45,7 +45,7 @@ function ShareModal(props) {
     <button className="btn btn-outline-primary my-1" onClick={handleOpen}>Share</button>
     <Snackbar open={openSnack} autoHideDuration={6000} onClose={handleSnackClose}>
       <div className="alert alert-success">
-        Copied to clipboard
+        Embed code copied to clipboard
       </div>
     </Snackbar>
 
@@ -66,11 +66,11 @@ function ShareModal(props) {
             <button type="button" className="btn btn-link" onClick={openIframeCode ? handleIframeCodeClose : handleIframeCodeOpen}>Get embed code</button>
           </div>
           {
-            openIframeCode && <div className="modal-footer justify-content-start row">
-              <textarea value={iframeCode} readOnly className="col-7" />
-              <div className="col-4">
-                <button type="button" className="btn btn-link" onClick={handleIframeCodeClose}>Cancel</button>
-                <button type="button" className="btn btn-primary" onClick={handleCopyIframeCode}>Copy</button>
+            openIframeCode && <div className="modal-footer justify-content-start share-modal">
+              <textarea value={iframeCode} readOnly className="embed-textarea p-2" />
+              <div className="col-12 pt-2 px-2">
+                <button type="button" className="btn btn-primary float-end" onClick={handleCopyIframeCode}>Copy</button>
+                <button type="button" className="btn btn-link float-end" onClick={handleIframeCodeClose}>Cancel</button>
               </div>
             </div>
           }


### PR DESCRIPTION
It doesn't seem like there's any reason we can't make it easier for the user to edit the embed code, so I made the textarea bigger and adjusted a few other things, like making the success message a bit more context-specific.

## Before
<img width="520" alt="Screen Shot 2021-04-06 at 6 25 12 PM" src="https://user-images.githubusercontent.com/101482/113797176-9aa3f880-9705-11eb-9b36-e9efe9f741ef.png">

## After
<img width="605" alt="Screen Shot 2021-04-06 at 6 19 14 PM" src="https://user-images.githubusercontent.com/101482/113797187-a0014300-9705-11eb-8b8c-75f4ca3d348c.png">
