### PR TITLE
Hook up a project-level iiif collection with the workspace catalog

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -19,6 +19,12 @@ class ResourcesController < ApplicationController
   # GET /resources/1/edit
   def edit; end
 
+  def iiif
+    respond_to do |format|
+      format.json
+    end
+  end
+
   # POST /resources or /resources.json
   def create
     respond_to do |format|

--- a/app/javascript/components/Viewer.js
+++ b/app/javascript/components/Viewer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Mirador from 'mirador/dist/es/src/index';
 import miradorImageToolsPlugin from 'mirador-image-tools/es/plugins/miradorImageToolsPlugin';
-import { importMiradorState } from 'mirador/dist/es/src/state/actions';
+import { addResource, importMiradorState } from 'mirador/dist/es/src/state/actions';
 import { getExportableState } from 'mirador/dist/es/src/state/selectors';
 
 /** */
@@ -10,7 +10,7 @@ class Viewer extends React.Component {
   /** */
   componentDidMount() {
     const {
-      config, enabledPlugins, state, updateStateSelector,
+      config, enabledPlugins, state, updateStateSelector, projectResourcesUrl,
     } = this.props;
 
     delete config.export;
@@ -22,6 +22,7 @@ class Viewer extends React.Component {
       ],
     );
     if (state) instance.store.dispatch(importMiradorState({ ...state, config: instance.store.getState().config }));
+    if (projectResourcesUrl) instance.store.dispatch(addResource(projectResourcesUrl))
     if (updateStateSelector) {
       instance.store.subscribe(() => {
         const currentState = instance.store.getState();
@@ -44,6 +45,7 @@ Viewer.propTypes = {
   config: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   enabledPlugins: PropTypes.array, // eslint-disable-line react/forbid-prop-types,
   state: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  projectResourcesUrl: PropTypes.string,
   updateStateSelector: PropTypes.string,
 };
 
@@ -51,6 +53,7 @@ Viewer.defaultProps = {
   config: {},
   enabledPlugins: [],
   state: null,
+  projectResourcesUrl: null,
   updateStateSelector: null,
 };
 

--- a/app/views/resources/iiif.json.jbuilder
+++ b/app/views/resources/iiif.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.set! :@context, 'http://iiif.io/api/presentation/2/context.json'
+json.set! :@id, iiif_project_resources_path(@project)
+json.set! :@type, 'sc:Collection'
+json.label @project.title
+json.viewingHint 'top'
+json.description @project.description if @project.description
+json.manifests do
+end
+
+json.total 0

--- a/app/views/workspaces/edit.html.erb
+++ b/app/views/workspaces/edit.html.erb
@@ -19,7 +19,8 @@
         {
           config: { id: "m-#{SecureRandom.hex}" }.deep_merge(@workspace.state&.dig('config') || {}),
           state: @workspace.state,
-          updateStateSelector: '#workspace_state'
+          updateStateSelector: '#workspace_state',
+          projectResourcesUrl: iiif_project_resources_url(@workspace.project),
         }
       )
   %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   resources :projects do
     resources :workspaces, except: %i[show destroy edit]
-    resources :resources, except: %i[show destroy edit]
+    resources :resources, except: %i[show destroy edit] do
+      collection do
+        get 'iiif', defaults: { format: :json }
+      end
+    end
   end
 
   resources :workspaces, only: %i[index show destroy edit update] do


### PR DESCRIPTION
TODO:
- [ ] populate the iiif collection from the workspaces
- [ ] have mirador export the manifest labels (+ type?)
- [ ] special handling for drag+drop uploaded images(?)
<img width="979" alt="Screen Shot 2021-04-08 at 07 40 19" src="https://user-images.githubusercontent.com/111218/114046401-ac88b700-983d-11eb-97a3-9b03a6d09792.png">
