### PR TITLE
Disable turbolinks on workspace/show

### DIFF
--- a/app/views/workspaces/_card.html.erb
+++ b/app/views/workspaces/_card.html.erb
@@ -11,7 +11,7 @@
       <p>Last edited <%= time_ago_in_words(workspace.updated_at) %> ago</p>
       <% options = capture do %>
         <% if can? :read, workspace %>
-          <li><%= link_to 'Open workspace', viewer_workspace_path(workspace), class: 'dropdown-item' %></li>
+          <li><%= link_to 'Open workspace', viewer_workspace_path(workspace), class: 'dropdown-item', data: { turbolinks: false } %></li>
         <% end %>
         <% if can? :duplicate, workspace %>
           <li><%= link_to 'Duplicate workspace', project_workspaces_path(workspace.project, template: workspace), class: 'dropdown-item', method: :post %></li>

--- a/app/views/workspaces/show.html.erb
+++ b/app/views/workspaces/show.html.erb
@@ -20,7 +20,7 @@
       <h1><%= @workspace.title %></h1>
       <%= @workspace.description %>
     <% end %>
-    <%= link_to(viewer_workspace_url(@workspace)) do %>
+    <%= link_to(viewer_workspace_url(@workspace), data: { turbolinks: false }) do %>
       <div class="card workspace-card my-3">
         <% if @workspace.thumbnail.present? %>
           <%= image_tag @workspace.thumbnail.presence.variant(resize_to_limit: [400, 400]), class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 400px; width: 100%' %>
@@ -40,7 +40,7 @@
       <%= react_component("ShareModal", { embedLink: embed_workspace_url(@workspace) }) %>
 
       <h2 class="h4">Workspace actions</h2>
-      <%= link_to 'Open workspace', viewer_workspace_path(@workspace), class: 'btn btn-outline-primary my-1' %>
+      <%= link_to 'Open workspace', viewer_workspace_path(@workspace), class: 'btn btn-outline-primary my-1', data: { turbolinks: false } %>
       <% if can? :update, @workspace %>
         <%= button_tag 'Move workspace', class: 'btn btn-outline-primary my-1', data: { 'bs-toggle': 'modal', 'bs-target': '#moveWorkspaceModal' } %>
         <div class="modal fade" id="moveWorkspaceModal" tabindex="-1" aria-labelledby="moveWorkspaceModalLabel" aria-hidden="true">


### PR DESCRIPTION
This was causing an issue where mirador was initializing twice when deployed