### PR TITLE
Styling refinements

### DIFF
--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -2,16 +2,16 @@
   <%= render(partial: 'layouts/sidebar') %>
 <% end %>
 
-<h1 class="display-5">Dashboard</h1>
+<h1>Dashboard</h1>
 
 <% if @favorites.any? %>
-  <h2 class="mt-3">Favorite workspaces</h2>
+  <h2 class="h3 mt-4 py-2 border-top">Favorite workspaces</h2>
   <div class="row workspace-cards g-4">
     <%= render partial: 'workspaces/card', collection: @favorites, as: :workspace %>
   </div>
 <% end %>
 
-<h2 class="mt-3">Recent workspace activity</h2>
+<h2 class="h3 mt-5 py-2 border-top">Recent workspace activity</h2>
 <div class="row workspace-cards g-4">
   <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
 </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div class="p-3 bg-white sidebar-nav">
+<div class="px-3 py-4 bg-white sidebar-nav">
   <ul class="list-unstyled ps-0">
     <li class="nav-item">
       <%= link_to 'Dashboard', root_path, class: ['nav-link', ('active' if current_page?(root_path))].join(' '), aria: { current: ('page' if current_page?(root_path)) } %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -13,7 +13,7 @@
     <% if current_user&.projects&.any? %>
       <li class="mb-1 nav-item">
         <div class="collapse show" id="home-collapse">
-          <ul class="btn-toggle-nav fw-normal ps-3 project-list">
+          <ul class="btn-toggle-nav fw-normal project-list">
             <% current_user.projects.order(title: :asc).each do |project| %>
               <li><%= link_to project.title, project, class: "link-dark rounded ms-0 #{'active' if @project == project }", data: { field: 'title', uuid: project.slug } %></li>
             <% end %>
@@ -32,7 +32,7 @@
     <% end %>
 
     <% if new_content.present? %>
-      <li class="nav-item mt-3 border-top pt-3">
+      <li class="nav-item mt-3 ms-3 border-top pt-3">
         <div class="dropdown">
           <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="newDropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
             + New

--- a/app/views/layouts/project.html.erb
+++ b/app/views/layouts/project.html.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% content_for(:top_level_nav) do %>
-  <%= content_tag :h1, @project.title, class: 'display-5', data: { field: 'title', uuid: @project.slug } %>
+  <%= content_tag :h1, @project.title, data: { field: 'title', uuid: @project.slug } %>
 
-  <ul class="nav nav-tabs">
+  <ul class="nav nav-tabs mt-4">
     <li class="nav-item">
       <%= link_to 'Project details', @project, class: "nav-link fw-bold #{'active' if current_page? @project }", aria: { current: ('page' if current_page? @project) } %>
     </li>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,9 +1,9 @@
 <div class="card p-3 my-4">
   <div class="row g-0">
     <div class="col-4">
-      <h2><%= link_to project.title, project %></h2>
+      <h2 class="h3 mb-3"><%= link_to project.title, project %></h2>
       <div><%= link_to pluralize(project.workspaces_count, 'workspace'), project_workspaces_path(project) %></div>
-      <p><%= project.description %></p>
+      <p class="my-3 me-4"><%= project.description %></p>
     </div>
 
     <div class="col">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,9 +1,9 @@
 <% title @project.title %>
 
-<div class="d-flex mt-3">
-  <div class="col">
+<div class="d-flex">
+  <div class="col me-4">
     <% if can? :update, @project %>
-      <div class="h4">
+      <div class="h4 mt-4">
         <%= react_component("EditInPlace", { field: 'title', value: @project.title, csrfToken: form_authenticity_token, uuid: @project.slug }) %>
       </div>
 
@@ -12,7 +12,7 @@
       </div>
 
       <%= form_with(model: @project) do |form| %>
-        <div class="form-check">
+        <div class="form-check my-3">
           <label class="form-check-label">
             <%= form.check_box :published, class: 'form-check-input', onChange: 'this.form.submit()' %>
             Visible to public
@@ -20,14 +20,12 @@
         </div>
       <% end %>
     <% else %>
-      <h1><%= @project.title %></h1>
+      <h1 class="h4 mt-4"><%= @project.title %></h1>
 
       <div><%= @project.description %></div>
     <% end %>
 
-    <%= link_to 'New workspace', project_workspaces_path(@project), method: :post, class: 'btn btn-outline-secondary mt-3' if @project && can?(:add_to, @project) %>
-
-    <h2 class="mt-3">Recent activity</h2>
+    <h2 class="h3 mt-5 py-2 border-top">Recent activity</h2>
     <div class="row workspace-cards g-4">
       <%= render partial: 'workspaces/card', collection: @project.workspaces.accessible_by(current_ability).order(updated_at: :desc).first(2), as: :workspace %>
     </div>
@@ -35,7 +33,7 @@
     <% favorites = @project.workspaces.favorites.accessible_by(current_ability) %>
 
     <% if favorites.any? %>
-      <h2 class="mt-3">Favorite workspaces</h2>
+      <h2 class="h3 mt-5 py-2 border-top">Favorite workspaces</h2>
       <div class="row workspace-cards g-4">
         <%= render partial: 'workspaces/card', collection: favorites.order(updated_at: :desc), as: :workspace %>
       </div>
@@ -43,16 +41,17 @@
   </div>
 
   <div class="col-3 border-start border-2 h-100">
-    <nav class="d-flex flex-column mt-2 ms-2 align-items-start">
+    <nav class="d-flex flex-column ms-4 align-items-start">
       <% if can? :update, @project %>
-        <h2 class="h4">Shared with</h2>
+        <h2 class="h4 mt-4">Shared with</h2>
         <% User.with_role(:admin, @project).each do |user| %>
           <div><%= user.uid %></div>
         <% end %>
       <% end %>
 
-      <h2 class="h4">Project actions</h2>
-      <%= link_to 'Delete project', @project, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-danger my-1' if can? :delete, @project %>
+      <h2 class="h4 mt-4">Project actions</h2>
+      <%= link_to 'New workspace', project_workspaces_path(@project), method: :post, class: 'btn btn-outline-secondary my-2' if @project && can?(:add_to, @project) %>
+      <%= link_to 'Delete project', @project, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-danger my-2' if can? :delete, @project %>
     </nav>
   </div>
 </div>

--- a/app/views/workspaces/_card.html.erb
+++ b/app/views/workspaces/_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card workspace-card">
+<div class="card workspace-card mb-3">
   <%= link_to workspace do %>
     <%= image_tag workspace.thumbnail.presence&.variant(resize_to_limit: [400, 400]) || 'placeholder.png', class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 200px' %>
   <% end %>

--- a/app/views/workspaces/index.html.erb
+++ b/app/views/workspaces/index.html.erb
@@ -1,6 +1,6 @@
 <% if @project %>
   <% title [@project.title, 'Workspaces']  %>
-  <h2>Workspaces</h2>
+  <h2 class="h3 mt-4 pb-2">Workspaces</h2>
 <% else %>
   <% title 'Workspaces' %>
   <h1>All workspaces</h1>
@@ -13,4 +13,4 @@
   <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
 </div>
 
-<%= link_to 'New workspace', project_workspaces_path(@project), method: :post, class: 'btn btn-outline-secondary mt-3' if @project && can?(:add_to, @project) %>
+<%= link_to 'New workspace', project_workspaces_path(@project), method: :post, class: 'btn btn-outline-secondary mt-4' if @project && can?(:add_to, @project) %>

--- a/app/views/workspaces/index.html.erb
+++ b/app/views/workspaces/index.html.erb
@@ -1,9 +1,9 @@
 <% if @project %>
   <% title [@project.title, 'Workspaces']  %>
-  <h2 class="h3 mt-4 pb-2">Workspaces</h2>
+  <h2 class="h3 mt-4 mb-3">Workspaces</h2>
 <% else %>
   <% title 'Workspaces' %>
-  <h1>All workspaces</h1>
+  <h1 class="mb-3">All workspaces</h1>
 <% end %>
 <% content_for(:sidebar) do %>
   <%= render(partial: 'layouts/sidebar') %>

--- a/app/views/workspaces/show.html.erb
+++ b/app/views/workspaces/show.html.erb
@@ -1,17 +1,19 @@
 <% title @workspace.title %>
 
 <div class="d-flex">
-  <div class="col">
+  <div class="col me-4">
     <% if can? :update, @workspace %>
-      <%= react_component("EditInPlace", { field: 'title', value: @workspace.title, csrfToken: form_authenticity_token }, tag: 'h1') %>
+      <div class="h4 mt-4">
+        <%= react_component("EditInPlace", { field: 'title', value: @workspace.title, csrfToken: form_authenticity_token }) %>
+      </div>
 
       <span class="fst-italic">Last updated <%= time_ago_in_words(@workspace.updated_at) %> ago <%= "by #{User.find(@workspace.paper_trail.originator)&.uid}" if @workspace.paper_trail.originator.present? %></span>
-      <div>
+      <div class="mt-3">
         <%= react_component("EditInPlace", { field: 'description', placeholder: 'Workspace description', value: @workspace.description, csrfToken: form_authenticity_token }) %>
       </div>
 
       <%= form_with(model: @workspace) do |form| %>
-        <div class="form-check">
+        <div class="form-check mt-3">
           <label class="form-check-label">
             <%= form.check_box :published, class: 'form-check-input', onChange: 'this.form.submit()' %>
             Visible to public
@@ -19,32 +21,33 @@
         </div>
       <% end %>
     <% else %>
-      <h1><%= @workspace.title %></h1>
+      <h1 class="h4 mt-4"><%= @workspace.title %></h1>
       <%= @workspace.description %>
     <% end %>
-    <%= link_to(viewer_workspace_url(@workspace), data: { turbolinks: false }) do %>
       <div class="card workspace-card my-3">
-        <% if @workspace.thumbnail.present? %>
-          <%= image_tag @workspace.thumbnail.presence.variant(resize_to_limit: [400, 400]), class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 400px; width: 100%' %>
-        <% else %>
-           <%= image_tag 'placeholder.png', class: 'card-img-top' %>
+        <%= link_to(viewer_workspace_url(@workspace), data: { turbolinks: false }) do %>
+          <% if @workspace.thumbnail.present? %>
+            <%= image_tag @workspace.thumbnail.presence.variant(resize_to_limit: [400, 400]), class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 400px; width: 100%' %>
+          <% else %>
+             <%= image_tag 'placeholder.png', class: 'card-img-top' %>
+          <% end %>
+          <span class="caption-overlay">
+            <span class="btn btn-primary stretched-link">Open workspace</span>
+          </span>
         <% end %>
-        <span class="caption-overlay">
-          <span class="btn btn-primary stretched-link">Open workspace</span>
-        </span>
       </div>
-    <% end %>
   </div>
+
   <div class="col-3 border-start border-2 h-100">
-    <nav class="d-flex flex-column mt-2 ms-2 align-items-start">
-      <h2 class="h4">Share</h2>
+    <nav class="d-flex flex-column ms-4 align-items-start">
+      <h2 class="h4 mt-4">Share</h2>
 
       <%= react_component("ShareModal", { embedLink: embed_workspace_url(@workspace) }) %>
 
-      <h2 class="h4">Workspace actions</h2>
-      <%= link_to 'Open workspace', viewer_workspace_path(@workspace), class: 'btn btn-outline-primary my-1', data: { turbolinks: false } %>
+      <h2 class="h4 mt-4">Workspace actions</h2>
+      <%= link_to 'Open workspace', viewer_workspace_path(@workspace), class: 'btn btn-outline-primary my-2', data: { turbolinks: false } %>
       <% if can? :update, @workspace %>
-        <%= button_tag 'Move workspace', class: 'btn btn-outline-primary my-1', data: { 'bs-toggle': 'modal', 'bs-target': '#moveWorkspaceModal' } %>
+        <%= button_tag 'Move workspace', class: 'btn btn-outline-primary my-2', data: { 'bs-toggle': 'modal', 'bs-target': '#moveWorkspaceModal' } %>
         <div class="modal fade" id="moveWorkspaceModal" tabindex="-1" aria-labelledby="moveWorkspaceModalLabel" aria-hidden="true">
           <%= form_with(model: @workspace, class: 'me-2 modal-dialog move-workspace') do |form| %>
             <div class="modal-content">
@@ -68,8 +71,8 @@
           <% end %>
         </div>
       <% end %>
-      <%= link_to 'Duplicate workspace', project_workspaces_path(@workspace.project, template: @workspace), class: 'btn btn-outline-secondary my-1', method: :post if can? :duplicate, @workspace %>
-      <%= link_to 'Delete workspace', workspace_path(@workspace), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-danger my-1' if can? :delete, @workspace %>
+      <%= link_to 'Duplicate workspace', project_workspaces_path(@workspace.project, template: @workspace), class: 'btn btn-outline-secondary my-2', method: :post if can? :duplicate, @workspace %>
+      <%= link_to 'Delete workspace', workspace_path(@workspace), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-danger my-2' if can? :delete, @workspace %>
     </nav>
   </div>
 </div>


### PR DESCRIPTION
Mostly straightforward styling updates just to refine headings sizes and adding spacing here and there.

One thing that wasn't really styling but I think is okay (i.e., everything still seems to work as intended) was to move the link that surrounds the workspace card on the [workspace show page](app/views/workspaces/show.html.erb). The placement of the link made it so the whole row that the workspace card was on was linked (i.e., all the whitespace to the right of the card until you hit the sidebar). Having a bunch of whitespace on the page be linked was confusing and I kept launching the workspace viewer without intending to. So I think my moving the link in the code just makes the behavior work as intended, but feel free to double-check that I'm not missing something in doing this.

Couple of example screenshots showing the PR changes:

<img width="1510" alt="Screen Shot 2021-04-16 at 2 03 16 PM" src="https://user-images.githubusercontent.com/101482/115084229-6bd41200-9ebd-11eb-857a-9a05ae188db6.png">

---

<img width="1510" alt="Screen Shot 2021-04-16 at 2 03 31 PM" src="https://user-images.githubusercontent.com/101482/115084246-71c9f300-9ebd-11eb-8cef-daf3c88db80d.png">

---

<img width="1525" alt="Screen Shot 2021-04-16 at 2 13 11 PM" src="https://user-images.githubusercontent.com/101482/115084524-e8ff8700-9ebd-11eb-9d68-0ef1876629b1.png">

