### PR TITLE
Update styling and layout of Projects page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,7 @@ $body-bg: #f3f3f3;
   margin-right: calc(var(--bs-gutter-x) / 2);
   max-width: 18rem;
 }
+
+.project-description {
+  max-width: 65ch;
+}

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,19 +1,20 @@
 <div class="card p-3 my-4">
   <div class="row g-0">
-    <div class="col-4">
-      <h2 class="h3 mb-3"><%= link_to project.title, project %></h2>
-      <div><%= link_to pluralize(project.workspaces_count, 'workspace'), project_workspaces_path(project) %></div>
-      <p class="my-3 me-4"><%= project.description %></p>
-    </div>
-
     <div class="col">
-      <div class="row workspace-cards">
-        <%= render partial: 'workspaces/card', collection: project.workspaces.first(2), as: :workspace %>
-      </div>
+      <h2 class="h3 mb-3 d-flex justify-content-between"><%= link_to project.title, project %>
+        <span class="fs-6 badge bg-light border">
+          <%= link_to pluralize(project.workspaces_count, 'workspace'), project_workspaces_path(project) %>
+        </span>
+      </h2>
+      <p class="my-3 me-4 project-description"><%= project.description %></p>
     </div>
+  </div>
 
-    <div class="col-1 ps-2 align-self-center">
-      <%= link_to 'View all', project_workspaces_path(project), class: 'btn btn-outline-secondary' %>
+  <div class="row g-0">
+    <div class="col">
+      <div class="workspace-cards d-lg-flex justify-content-lg-evenly">
+        <%= render partial: 'workspaces/card', collection: project.workspaces.first(3), as: :workspace %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/workspaces/_card.html.erb
+++ b/app/views/workspaces/_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card workspace-card mb-3">
+<div class="card workspace-card mb-3 mx-2 border-2">
   <%= link_to workspace do %>
     <%= image_tag workspace.thumbnail.presence&.variant(resize_to_limit: [400, 400]) || 'placeholder.png', class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 200px' %>
   <% end %>
@@ -8,7 +8,7 @@
     <%= react_component 'Favorite', favorite: workspace.favorite, csrfToken: form_authenticity_token, updateUrl: workspace_path(workspace) %>
 
     <div class="d-flex flex-grow-1 justify-content-between">
-      <p>Last edited <%= time_ago_in_words(workspace.updated_at) %> ago</p>
+      <p class="small-font-size">Last edited <%= time_ago_in_words(workspace.updated_at) %> ago</p>
       <% options = capture do %>
         <% if can? :read, workspace %>
           <li><%= link_to 'Open workspace', viewer_workspace_path(workspace), class: 'dropdown-item', data: { turbolinks: false } %></li>


### PR DESCRIPTION
I wanted to improve the layout below, where it seems like we're wasting a lot of white space with the arrangement of the workspace cards and the "View all" button (which is the way I mocked it up, so that's my fault).

<img width="992" alt="before" src="https://user-images.githubusercontent.com/101482/117075663-120b7e80-acea-11eb-9bb7-980d59424004.png">

---

So this PR:

- gets rid of the "View all" button (I'm assuming the "N workspaces" link is a good enough surrogate for that)
- adjusts the flexbox stuff a bit so that at `lg` and above viewports 3 workspace cards fit in a row (the cards shrink a bit as you get closer to `md` but still look fine to me)
- at `md` and below the cards just go into a single column as they did before
- some very minor miscellaneous styling adjustments, like making the workspace card border just a bit wider and limiting the line length of the project description for readability

I don't think I did anything too weird with the flexbox rearrangement (the layout works fine on all 3 main browsers) but I'm no expert so if anyone sees anything that looks wrong definitely let me know and I can fix.

## Examples at different viewport widths
<img width="1053" alt="Screen Shot 2021-05-04 at 3 00 57 PM" src="https://user-images.githubusercontent.com/101482/117076045-a4ac1d80-acea-11eb-8168-6d67c6580a24.png">

---

<img width="750" alt="Screen Shot 2021-05-04 at 3 01 24 PM" src="https://user-images.githubusercontent.com/101482/117076080-b392d000-acea-11eb-849d-2f685f487ab7.png">

---

<img width="491" alt="Screen Shot 2021-05-04 at 3 01 49 PM" src="https://user-images.githubusercontent.com/101482/117076086-b8578400-acea-11eb-92f3-ec96f93b7c0c.png">

