### PR TITLE
Add messages for 'no workspaces' scenarios

### DIFF
--- a/app/views/home/dashboard.html.erb
+++ b/app/views/home/dashboard.html.erb
@@ -11,7 +11,11 @@
   </div>
 <% end %>
 
-<h2 class="h3 mt-5 py-2 border-top">Recent workspace activity</h2>
-<div class="row workspace-cards g-4">
-  <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
-</div>
+  <h2 class="h3 mt-5 py-2 border-top">Recent workspace activity</h2>
+  <% if @workspaces.any? %>
+    <div class="row workspace-cards g-4">
+      <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
+    </div>
+  <% else %>
+    <p class="fst-italic">There hasn't been any recent activity on your workspaces.</p>
+  <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,10 +25,14 @@
       <div><%= @project.description %></div>
     <% end %>
 
-    <h2 class="h3 mt-5 py-2 border-top">Recent activity</h2>
-    <div class="row workspace-cards g-4">
-      <%= render partial: 'workspaces/card', collection: @project.workspaces.accessible_by(current_ability).order(updated_at: :desc).first(2), as: :workspace %>
-    </div>
+    <h2 class="h3 mt-5 py-2 border-top">Recent workspace activity</h2>
+    <% if @project.workspaces.any? %>
+      <div class="row workspace-cards g-4">
+        <%= render partial: 'workspaces/card', collection: @project.workspaces.accessible_by(current_ability).order(updated_at: :desc).first(2), as: :workspace %>
+      </div>
+    <% else %>
+      <p class="fst-italic">There hasn't been any recent workspace activity in this project.</p>
+    <% end %>
 
     <% favorites = @project.workspaces.favorites.accessible_by(current_ability) %>
 

--- a/app/views/workspaces/index.html.erb
+++ b/app/views/workspaces/index.html.erb
@@ -9,8 +9,16 @@
   <%= render(partial: 'layouts/sidebar') %>
 <% end unless @project %>
 
-<div class="row workspace-cards g-4 flex-wrap align-self-stretch">
-  <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
-</div>
+<% if @workspaces.any? %>
+  <div class="row workspace-cards g-4 flex-wrap align-self-stretch">
+    <%= render partial: 'workspaces/card', collection: @workspaces, as: :workspace %>
+  </div>
+<% else %>
+  <% if @project %>
+    <p class="fst-italic">There are no workspaces in this project.</p>
+  <% else %>
+    <p class="fst-italic">You don't have any workspaces. To create a workspace, first select a project.</p>
+  <% end %>
+<% end %>
 
 <%= link_to 'New workspace', project_workspaces_path(@project), method: :post, class: 'btn btn-outline-secondary mt-4' if @project && can?(:add_to, @project) %>


### PR DESCRIPTION
Added a message for the contexts where, if the user has no workspaces or recent activity, the lack of message seemed kind of lacking.

Other than the message strings themselves, this is just adding `<% if %> <% else %> <% end %>` statements, which I assume I got right (everything still works as before when the user does have a workspace or activity).

Below are the places with the new messages:

<img width="974" alt="Screen Shot 2021-05-05 at 3 54 37 PM" src="https://user-images.githubusercontent.com/101482/117220105-6cc0db00-adbb-11eb-8308-98740fce2e75.png">

---

<img width="974" alt="Screen Shot 2021-05-05 at 3 54 52 PM" src="https://user-images.githubusercontent.com/101482/117220117-721e2580-adbb-11eb-8da9-aed0bc64fcd2.png">

---

<img width="974" alt="Screen Shot 2021-05-05 at 3 55 13 PM" src="https://user-images.githubusercontent.com/101482/117220125-764a4300-adbb-11eb-8012-4ac1113bf193.png">

--- 

<img width="968" alt="Screen Shot 2021-05-05 at 3 55 28 PM" src="https://user-images.githubusercontent.com/101482/117220132-79ddca00-adbb-11eb-8daa-b3108565d47f.png">
