### PR TITLE
Pin react-paperjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^1.7.0",
     "webpack-dev-server": "^3.11.2"
+  },
+  "resolutions": {
+    "@psychobolt/react-paperjs": "1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,10 +1086,10 @@
   resolved "https://registry.yarnpkg.com/@psychobolt/react-paperjs-editor/-/react-paperjs-editor-0.0.14.tgz#9d159407be0332b7aeb1e20847875ff6150fc6ac"
   integrity sha512-8sqgK+CBv2lD5hS0loX87Yy9CCUhzefkBfh2kMwfMnMd/A7mkJBDUK7UQ1vmAX4D3myoovr3WE3YdJIjD+xm7A==
 
-"@psychobolt/react-paperjs@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@psychobolt/react-paperjs/-/react-paperjs-1.0.1.tgz#1ef7643ba8b606524b50e27d7b2b58f065a08a73"
-  integrity sha512-zTKBUBMIepd0Drgv7/+t4GYhZrDsiyuTnrKFXwTgNgyCWony65CLJYUoPuzWN5zEm3KrUHGzEq6st6S/lgabYA==
+"@psychobolt/react-paperjs@1.0.0", "@psychobolt/react-paperjs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@psychobolt/react-paperjs/-/react-paperjs-1.0.0.tgz#fe45f98c7dec9c31d2eda99c0dc6496776cf7293"
+  integrity sha512-V1kyGv+9JLPGFtYJWnWQwbZLGRa+4wKM6FIITbZYePot23LYt8mpy6ztv/qmq+xZUKhOAacWImjXqtCFiNmy2w==
   dependencies:
     react-is "^16.13.1"
 


### PR DESCRIPTION
Fixes:

> I know it was working fairly recently, but when I gave a demo a few minutes ago I got an error when I tried selecting a shape to add an annotation target (both -prod and -stage). The annotation sidebar opens, but it seems that any action within it triggers the error. (The plugin demo at https://mirador-annotations.netlify.app/ still works.)

<img width="278" alt="Screen Shot 2021-05-07 at 11 39 19 AM" src="https://user-images.githubusercontent.com/111218/117510672-580e4f80-af41-11eb-9dc3-3381ab6a1551.png">
