### PR TITLE
Guard against workspaces without resources

### DIFF
--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -23,13 +23,17 @@ class Workspace < ApplicationRecord
   end
 
   def catalog_resources
-    state&.dig('catalog')&.pluck('manifestId')&.map do |manifest_id|
+    manifest_ids.map do |manifest_id|
       {
         label: state&.dig('__mise_cache__', 'manifests', manifest_id, 'label'),
         '@type': state&.dig('__mise_cache__', 'manifests', manifest_id, '@type'),
         '@id': manifest_id
       }
     end
+  end
+
+  def manifest_ids
+    state&.dig('catalog')&.pluck('manifestId') || []
   end
 
   before_validation do

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -1,2 +1,11 @@
 <h2 class="h3 mt-4 mb-3">Resources</h2>
-<%= render 'resource_list', resources: @catalog_resources %>
+
+<% if @catalog_resources.empty? %>
+  <% if @project %>
+    <p class="fst-italic">There are no resources in this project.</p>
+  <% else %>
+    <p class="fst-italic">You don't have any resources.</p>
+  <% end %>
+<% else %>
+  <%= render 'resource_list', resources: @catalog_resources %>
+<% end %>

--- a/spec/models/workspace_spec.rb
+++ b/spec/models/workspace_spec.rb
@@ -54,4 +54,10 @@ RSpec.describe Workspace do
       expect(workspace.attributes_for_template).to include 'title' => 'Duplicate of project 1'
     end
   end
+
+  describe '#manifest_ids' do
+    it 'defaults to an empty array' do
+      expect(workspace.manifest_ids).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Fixes #138, and adds a placeholder message like the other tabs have when there is no data to show:

![Screen Shot 2021-05-19 at 13 03 54](https://user-images.githubusercontent.com/111218/118876929-abb65c80-b8a2-11eb-812a-7fdcd6354172.png)
