### PR TITLE
Add thumbnails, item count, and provider to Resources list

### DIFF
--- a/app/assets/stylesheets/resources.scss
+++ b/app/assets/stylesheets/resources.scss
@@ -2,6 +2,24 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.resources-list {
+  th:first-child, td:first-child {
+    width: 150px;
+    text-align: right;
+  }
+
+  .resource-thumbnail {
+    max-height: 120px;
+  }
+
+  .resource-thumbnail-placeholder {
+    background-color: darkgray;
+    display: inline-block;
+    height: 120px;
+    width: 120px;
+  }
+}
+
 .favorite-action {
   position: absolute;
   top: 0;

--- a/app/assets/stylesheets/resources.scss
+++ b/app/assets/stylesheets/resources.scss
@@ -4,19 +4,18 @@
 
 .resources-list {
   th:first-child, td:first-child {
-    width: 150px;
-    text-align: right;
+    width: 80px;
   }
 
   .resource-thumbnail {
-    max-height: 120px;
+    max-height: 50px;
   }
 
   .resource-thumbnail-placeholder {
     background-color: darkgray;
     display: inline-block;
-    height: 120px;
-    width: 120px;
+    height: 50px;
+    width: 50px;
   }
 }
 

--- a/app/javascript/components/Viewer.js
+++ b/app/javascript/components/Viewer.js
@@ -6,8 +6,7 @@ import miradorImageToolsPlugin from 'mirador-image-tools/es/plugins/miradorImage
 import miradorAnnotationsPlugins from 'mirador-annotations/es';
 import { addResource, importMiradorState } from 'mirador/dist/es/src/state/actions';
 import {
-  getExportableState, getManifestTitle, getManifestProvider,
-  getManifestoInstance, getCanvases
+  getExportableState, getManifestTitle, getManifestProvider, getManifestThumbnail, getManifestoInstance, getCanvases
 } from 'mirador/dist/es/src/state/selectors';
 import AnnototAdapter from 'mirador-annotations/es/AnnototAdapter';
 
@@ -72,6 +71,7 @@ class Viewer extends React.Component {
     return {
       label: getManifestTitle(state, { manifestId }),
       '@type': manifest.json.['@type'],
+      thumbnail: getManifestThumbnail(state, { manifestId }),
       itemcount: size,
       provider: getManifestProvider(state, { manifestId }),
     }

--- a/app/javascript/components/Viewer.js
+++ b/app/javascript/components/Viewer.js
@@ -5,8 +5,12 @@ import Mirador from 'mirador/dist/es/src/index';
 import miradorImageToolsPlugin from 'mirador-image-tools/es/plugins/miradorImageToolsPlugin';
 import miradorAnnotationsPlugins from 'mirador-annotations/es';
 import { addResource, importMiradorState } from 'mirador/dist/es/src/state/actions';
-import { getExportableState } from 'mirador/dist/es/src/state/selectors';
+import {
+  getExportableState, getManifestTitle, getManifestProvider,
+  getManifestoInstance, getCanvases
+} from 'mirador/dist/es/src/state/selectors';
 import AnnototAdapter from 'mirador-annotations/es/AnnototAdapter';
+
 
 /** */
 class Viewer extends React.Component {
@@ -41,13 +45,39 @@ class Viewer extends React.Component {
       instance.store.subscribe(() => {
         const currentState = instance.store.getState();
         const inputElement = document.querySelector(updateStateSelector);
-        const __mise_cache__ = { manifests: mapValues(currentState.manifests, m => (m.json && { label: m.json.label, '@type': m.json.['@type'] })) };
+        const __mise_cache__ = {
+          manifests: mapValues(currentState.manifests, m => this.getManifestCache(currentState, m))
+        };
         if (inputElement) {
           inputElement.value = JSON.stringify({ ...getExportableState(currentState), __mise_cache__ });
         }
       });
     }
   }
+
+  getManifestCache(state, manifest) {
+    if(!manifest.json) return;
+
+    const manifestId = manifest.id;
+
+    const manifesto = getManifestoInstance(state, { manifestId });
+    const isCollection = (
+      manifesto || { isCollection: () => false }
+    ).isCollection();
+
+    const size = isCollection
+      ? manifesto.getTotalItems()
+      : getCanvases(state, { manifestId }).length;
+
+    return {
+      label: getManifestTitle(state, { manifestId }),
+      '@type': manifest.json.['@type'],
+      itemcount: size,
+      provider: getManifestProvider(state, { manifestId }),
+    }
+  }
+
+
 
   /** */
   render() {

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -27,6 +27,8 @@ class Workspace < ApplicationRecord
       {
         label: state&.dig('__mise_cache__', 'manifests', manifest_id, 'label'),
         '@type': state&.dig('__mise_cache__', 'manifests', manifest_id, '@type'),
+        itemcount: state&.dig('__mise_cache__', 'manifests', manifest_id, 'itemcount'),
+        provider: state&.dig('__mise_cache__', 'manifests', manifest_id, 'provider'), # IIIF v3 only
         '@id': manifest_id
       }
     end

--- a/app/models/workspace.rb
+++ b/app/models/workspace.rb
@@ -29,6 +29,7 @@ class Workspace < ApplicationRecord
         '@type': state&.dig('__mise_cache__', 'manifests', manifest_id, '@type'),
         itemcount: state&.dig('__mise_cache__', 'manifests', manifest_id, 'itemcount'),
         provider: state&.dig('__mise_cache__', 'manifests', manifest_id, 'provider'), # IIIF v3 only
+        thumbnail: state&.dig('__mise_cache__', 'manifests', manifest_id, 'thumbnail'),
         '@id': manifest_id
       }
     end

--- a/app/views/resources/_resource.html.erb
+++ b/app/views/resources/_resource.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td>
+  <td class="text-end">
     <% if resource[:thumbnail].present? %>
       <%= image_tag resource[:thumbnail], alt:'', class: 'resource-thumbnail', skip_pipeline: true %>
     <% else %>
@@ -7,7 +7,7 @@
     <% end %>
   </td>
   <td><%= link_to resource[:label], url_for_project_resource(@project, resource) %></td>
-  <td><%= number_with_delimiter resource[:itemcount].to_i %></td>
-  <td><%= resource[:provider] %></td>
-  <td><%= iiif_drag_n_drop(url_for_project_resource(@project, resource)) %></td>
+  <td class="text-end"><%= number_with_delimiter resource[:itemcount].to_i %></td>
+  <!-- <td><%= resource[:provider] %></td> -->
+  <td class="text-end"><%= iiif_drag_n_drop(url_for_project_resource(@project, resource)) %></td>
 </tr>

--- a/app/views/resources/_resource.html.erb
+++ b/app/views/resources/_resource.html.erb
@@ -1,4 +1,11 @@
 <tr>
+  <td>
+    <% if resource[:thumbnail].present? %>
+      <%= image_tag resource[:thumbnail], alt:'', class: 'resource-thumbnail', skip_pipeline: true %>
+    <% else %>
+      <span class='resource-thumbnail-placeholder'></span>
+    <% end %>
+  </td>
   <td><%= link_to resource[:label], url_for_project_resource(@project, resource) %></td>
   <td><%= number_with_delimiter resource[:itemcount].to_i %></td>
   <td><%= resource[:provider] %></td>

--- a/app/views/resources/_resource.html.erb
+++ b/app/views/resources/_resource.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= link_to resource[:label], url_for_project_resource(@project, resource) %></td>
-  <td>...</td>
-  <td>...</td>
+  <td><%= number_with_delimiter resource[:itemcount].to_i %></td>
+  <td><%= resource[:provider] %></td>
   <td><%= iiif_drag_n_drop(url_for_project_resource(@project, resource)) %></td>
 </tr>

--- a/app/views/resources/_resource_list.html.erb
+++ b/app/views/resources/_resource_list.html.erb
@@ -1,6 +1,7 @@
-<table class="table table-borderless">
+<table class="resources-list table table-borderless">
   <thead>
     <tr>
+      <th scope="col"><span class="visually-hidden">Thumbnail</span></th>
       <th scope="col">Title</th>
       <th scope="col">Items</th>
       <th scope="col">Provider</th>

--- a/app/views/resources/_resource_list.html.erb
+++ b/app/views/resources/_resource_list.html.erb
@@ -3,9 +3,9 @@
     <tr>
       <th scope="col"><span class="visually-hidden">Thumbnail</span></th>
       <th scope="col">Title</th>
-      <th scope="col">Items</th>
-      <th scope="col">Provider</th>
-      <th scope="col">Actions</th>
+      <th scope="col" class="text-end">Items</th>
+      <!-- <th scope="col">Provider</th> -->
+      <th scope="col" class="text-end">Actions</th>
     </tr>
   </thead>
   <%= render partial: 'resource', collection: resources %>


### PR DESCRIPTION
Testing tip: if you want to test this out on an existing workspace, you'll need to `Save Workspace` to see these changes on the Resources tab.

### On the UI end: thumbnails, item counts, and providers in Resources list!
- `provider` is only available in IIIF Presentation v3. Peer institutions aren't publishing manifests in v3 by default.
  - [our v3 API](https://purl.stanford.edu/fr426cg9537/iiif3/manifest) is experimental and needs to be updated with several properties that were added in v3 since our original implementation
  - @ggeisler do we still want to render this column if it's going to be empty most of the time? We could try sticking v2 logos in there, but the alt-text for those could be pretty wanting. (e.g. Stanford `attribution` values seem to vary quite a bit: 
    - ["Copyright © Matt Kahn Living Trust. All Rights Reserved."](https://purl.stanford.edu/fr426cg9537/iiif/manifest)
    - ["Provided by the Stanford University Libraries"](https://purl.stanford.edu/wj335sy2632/iiif/manifest)
    - ["Bob Fitch photography archive, © Stanford University Libraries"](https://purl.stanford.edu/dh848vr8535/iiif/manifest)
 - Manifests without thumbnails get a `120px` x `120px` placeholder  

![Mise resources list](https://user-images.githubusercontent.com/5402927/118898950-92bda380-b8c2-11eb-8b43-a3b5aa4ab392.png)


### On the backend: stay ignorant about IIIF manifests!
- This PR taps into Mirador-provided selectors (and under the hood, [IIIF-Commons/manifesto](https://github.com/IIIF-Commons/manifesto/)). This helps mise stay out of the business of parsing IIIF manifests.
- https://github.com/ProjectMirador/mirador/blob/584466c9ed68bba4f83461ec9e2da39b7c09f61f/src/containers/ManifestListItem.js#L15-L41