### PR TITLE
Implement modals for duplicate and move workspace

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  */
 
 $body-bg: #f3f3f3;
+$light: #ced4da; // A darker grey than what Bootstrap ships
 @import 'bootstrap/scss/bootstrap';
 
 .small-font-size {

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -1,4 +1,4 @@
-.move-workspace {
+.move-workspace, .duplicate-workspace {
   label.btn {
     text-align: left;
     width: 100%;

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories. 
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))

--- a/app/javascript/controllers/show_modal_controller.js
+++ b/app/javascript/controllers/show_modal_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['container', 'title'];
+
+  copyFormTemplate(event) {
+    const modalFormTemplate = event.target.nextElementSibling;
+    this.containerTarget.innerHTML = modalFormTemplate.innerHTML;
+    this.titleTarget.innerText = event.target.innerText;
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,3 +20,5 @@ const componentRequireContext = require.context('components', true);
 const ReactRailsUJS = require('react_ujs');
 
 ReactRailsUJS.useContext(componentRequireContext);
+
+import "controllers"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
+  <body data-controller='show-modal'>
     <%= render 'layouts/navbar' %>
     <div class="main-content <%= 'with-sidebar' if content_for?(:sidebar) %>">
       <% if content_for?(:sidebar) %>
@@ -26,6 +26,18 @@
 
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
+
+      <div class="modal fade" id="workspaceModal" tabindex="-1" aria-labelledby="workspaceModalLabel" aria-hidden="true">
+        <div class="modal-dialog" tabindex="-1">
+          <div class="modal-content">
+            <div class="modal-header text-body bg-light">
+              <h5 class="modal-title h4" id="workspaceModalLabel" data-show-modal-target="title"></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div data-show-modal-target="container"></div>
+          </div>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/app/views/workspaces/_card.html.erb
+++ b/app/views/workspaces/_card.html.erb
@@ -13,9 +13,8 @@
         <% if can? :read, workspace %>
           <li><%= link_to 'Open workspace', viewer_workspace_path(workspace), class: 'dropdown-item', data: { turbolinks: false } %></li>
         <% end %>
-        <% if can? :duplicate, workspace %>
-          <li><%= link_to 'Duplicate workspace', project_workspaces_path(workspace.project, template: workspace), class: 'dropdown-item', method: :post %></li>
-        <% end %>
+        <%= render partial: 'workspaces/move_modal', locals: { button_classes: 'dropdown-item', workspace: workspace } %>
+        <%= render partial: 'workspaces/duplicate_modal', locals: { button_classes: 'dropdown-item', workspace: workspace } %>
         <% if can? :delete, workspace %>
           <li><%= link_to 'Delete workspace', workspace, class: 'dropdown-item', method: :delete, data: { confirm: 'Are you sure?' } %>
         <% end %>

--- a/app/views/workspaces/_duplicate_modal.html.erb
+++ b/app/views/workspaces/_duplicate_modal.html.erb
@@ -1,0 +1,17 @@
+      <% if can? :duplicate, workspace %>
+        <%= button_tag 'Duplicate workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
+        <template>
+          <%= form_with(scope: :workspace, namespace: "duplicate", url: workspaces_path(template: workspace), method: :post, class: 'me-2 duplicate-workspace') do |form| %>
+            <div class="modal-body">
+              <p>Where do you want the duplicated workspace to be created?</p>
+
+              <%= form.label :project_id, 'Select a project', class: 'mb-2' %>
+              <%= form.collection_select :project_id, Project.accessible_by(current_ability, :update), :id, :title, {}, class: 'form-select' %>
+            </div>
+            <div class="modal-footer justify-content-end">
+              <button type="button" class="btn btn-link" data-bs-dismiss="modal">Cancel</button>
+              <%= form.submit 'Duplicate', class: 'btn btn-primary'%>
+            </div>
+          <% end %>
+        </template>
+      <% end %>

--- a/app/views/workspaces/_move_modal.html.erb
+++ b/app/views/workspaces/_move_modal.html.erb
@@ -1,0 +1,17 @@
+      <% if can? :update, workspace %>
+        <%= button_tag 'Move workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
+        <template>
+          <%= form_with(model: workspace, namespace: 'move', class: 'me-2 move-workspace') do |form| %>
+            <div class="modal-body">
+              <p>Where do you want the workspace to be moved?</p>
+
+              <%= form.label :project_id, 'Select a project', class: 'mb-2' %>
+              <%= form.collection_select :project_id, Project.accessible_by(current_ability, :update), :id, :title, {}, class: 'form-select' %>
+            </div>
+            <div class="modal-footer justify-content-end">
+              <button type="button" class="btn btn-link" data-bs-dismiss="modal">Cancel</button>
+              <%= form.submit 'Move', class: 'btn btn-primary'%>
+            </div>
+          <% end %>
+        </template>
+      <% end %>

--- a/app/views/workspaces/show.html.erb
+++ b/app/views/workspaces/show.html.erb
@@ -54,32 +54,8 @@
 
       <h2 class="h4 mt-4">Workspace actions</h2>
       <%= link_to 'Open workspace', viewer_workspace_path(@workspace), class: 'btn btn-outline-primary my-2', data: { turbolinks: false } %>
-      <% if can? :update, @workspace %>
-        <%= button_tag 'Move workspace', class: 'btn btn-outline-primary my-2', data: { 'bs-toggle': 'modal', 'bs-target': '#moveWorkspaceModal' } %>
-        <div class="modal fade" id="moveWorkspaceModal" tabindex="-1" aria-labelledby="moveWorkspaceModalLabel" aria-hidden="true">
-          <%= form_with(model: @workspace, class: 'me-2 modal-dialog move-workspace') do |form| %>
-            <div class="modal-content">
-              <div class="modal-header">
-                <h5 class="modal-title" id="moveWorkspaceModalLabel">Move workspace</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              </div>
-              <div class="modal-body">
-                <%= form.collection_radio_buttons :project_id, Project.accessible_by(current_ability, :update), :id, :title do |b| %>
-                  <div>
-                    <%= b.radio_button class: 'btn-check' %>
-                    <%= b.label class: 'btn btn-outline-primary border-0' %>
-                  </div>
-                <% end %>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-link" data-bs-dismiss="modal">Close</button>
-                <%= form.submit 'Move', class: 'btn btn-primary'%>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-      <%= link_to 'Duplicate workspace', project_workspaces_path(@workspace.project, template: @workspace), class: 'btn btn-outline-secondary my-2', method: :post if can? :duplicate, @workspace %>
+      <%= render partial: 'workspaces/move_modal', locals: { button_classes: 'btn btn-outline-primary my-2', workspace: @workspace } %>
+      <%= render partial: 'workspaces/duplicate_modal', locals: { button_classes: 'btn btn-outline-secondary my-2', workspace: @workspace } %>
       <%= link_to 'Delete workspace', workspace_path(@workspace), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-danger my-2' if can? :delete, @workspace %>
     </nav>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :roles, only: %i[index create update destroy]
   end
 
-  resources :workspaces, only: %i[index show destroy edit update] do
+  resources :workspaces, except: :new do
     member do
       post 'duplicate'
       get 'embed'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react_ujs": "^2.6.1",
+    "stimulus": "^2.0.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,6 +1218,30 @@
   resolved "https://registry.yarnpkg.com/@researchgate/react-intersection-observer/-/react-intersection-observer-1.3.5.tgz#0321d2dd609aaacdb9bace8004d99c72824fb142"
   integrity sha512-aYlsex5Dd6BAHMJvJrUoFp8gzgMSL27xFvrxkVYW0bV1RMAapVsO+QeYLtTaSF/QCflktODodvv+wJm49oMnnQ==
 
+"@stimulus/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
+  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
+  dependencies:
+    "@stimulus/mutation-observers" "^2.0.0"
+
+"@stimulus/multimap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
+  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
+
+"@stimulus/mutation-observers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
+  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
+  dependencies:
+    "@stimulus/multimap" "^2.0.0"
+
+"@stimulus/webpack-helpers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
+  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -8579,6 +8603,14 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
+
+stimulus@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
+  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+  dependencies:
+    "@stimulus/core" "^2.0.0"
+    "@stimulus/webpack-helpers" "^2.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Fixes #135

Includes:
* Set up global workspace modal in the application layout (to avoid duplicated bootstrap modal HTML all over the place)
* Style the workspace modals identically
* Use StimulusJS to copy the template holding workspace-specific form and accompanying modal guts to the global workspace modal
* Re-use workspace modal partials across both the workspace/show and workspace card use cases
* Add a workspaces create route outside the project context to allow for easier duplication of workspaces (let cancancan do its thing)
* Align the move and duplicate modals with the design
  * Use a dropdown instead of radio buttons, and add the requested text and labels, doing so for both duplicate and move use cases.

# Screencast

![Peek 2021-05-20 10-16](https://user-images.githubusercontent.com/131982/119021639-83873600-b954-11eb-8205-873828575135.gif)
