### PR TITLE
Tune up workspace modals

### DIFF
--- a/app/views/workspaces/_duplicate_modal.html.erb
+++ b/app/views/workspaces/_duplicate_modal.html.erb
@@ -1,7 +1,7 @@
       <% if can? :duplicate, workspace %>
         <%= button_tag 'Duplicate workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
         <template>
-          <%= form_with(scope: :workspace, namespace: "duplicate", url: workspaces_path(template: workspace), method: :post, class: 'me-2 duplicate-workspace') do |form| %>
+          <%= form_with(model: workspace, namespace: "duplicate", url: workspaces_path(template: workspace), method: :post, class: 'me-2 duplicate-workspace') do |form| %>
             <div class="modal-body">
               <p>Where do you want the duplicated workspace to be created?</p>
 

--- a/app/views/workspaces/_duplicate_modal.html.erb
+++ b/app/views/workspaces/_duplicate_modal.html.erb
@@ -5,7 +5,7 @@
             <div class="modal-body">
               <p>Where do you want the duplicated workspace to be created?</p>
 
-              <%= form.label :project_id, 'Select a project', class: 'mb-2' %>
+              <%= form.label :project_id, 'Select a project', class: 'mb-2 fw-bold' %>
               <%= form.collection_select :project_id, Project.accessible_by(current_ability, :update), :id, :title, {}, class: 'form-select' %>
             </div>
             <div class="modal-footer justify-content-end">

--- a/app/views/workspaces/_move_modal.html.erb
+++ b/app/views/workspaces/_move_modal.html.erb
@@ -5,7 +5,7 @@
             <div class="modal-body">
               <p>Where do you want the workspace to be moved?</p>
 
-              <%= form.label :project_id, 'Select a project', class: 'mb-2' %>
+              <%= form.label :project_id, 'Select a project', class: 'mb-2 fw-bold' %>
               <%= form.collection_select :project_id, Project.accessible_by(current_ability, :update), :id, :title, {}, class: 'form-select' %>
             </div>
             <div class="modal-footer justify-content-end">


### PR DESCRIPTION
Fixes #146

Includes:
* Embolden the workspace modal dropdown labels …
* Fix bug with default project in duplicate workspace modal …
  * Form was not created with the given workspace instance therefore did not have knowledge of current project.
* Alternate flash message on workspace create & update …
  * This change makes flash notices for duplicates and moves more informative

# Screenshots + screencast

![move_workspace_modal_bold_label](https://user-images.githubusercontent.com/131982/119042898-4da27b80-b96d-11eb-8e2d-b38da447fc6d.png)
![duplicate_workspace_modal_bold_label](https://user-images.githubusercontent.com/131982/119042906-5004d580-b96d-11eb-9ff2-249f6fd08dd2.png)
![Peek 2021-05-20 13-11](https://user-images.githubusercontent.com/131982/119042930-55622000-b96d-11eb-8543-79db0a8dd1e0.gif)
