### PR TITLE
Add new workspace creation modal to sidebar

### DIFF
--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -1,4 +1,4 @@
-.move-workspace, .duplicate-workspace {
+.workspace-form {
   label.btn {
     text-align: left;
     width: 100%;

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -90,13 +90,13 @@ class WorkspacesController < ApplicationController
   private
 
   def create_notice
-    return 'Workspace was successfully created.' unless params[:template] && workspace_project_id.present?
+    return 'Your new workspace has been created.' unless params[:template] && workspace_project_id.present?
 
     "The '#{@workspace.title}' workspace was duplicated in '#{Project.find(workspace_project_id).title}.'"
   end
 
   def update_notice
-    return 'Workspace was successfully updated.' if workspace_project_id.blank?
+    return 'Your workspace has been updated.' if workspace_project_id.blank?
 
     "The '#{@workspace.title}' workspace was moved to '#{Project.find(workspace_project_id).title}.'"
   end

--- a/app/javascript/controllers/show_modal_controller.js
+++ b/app/javascript/controllers/show_modal_controller.js
@@ -6,6 +6,6 @@ export default class extends Controller {
   copyFormTemplate(event) {
     const modalFormTemplate = event.target.nextElementSibling;
     this.containerTarget.innerHTML = modalFormTemplate.innerHTML;
-    this.titleTarget.innerText = event.target.innerText;
+    this.titleTarget.innerText = modalFormTemplate.dataset.title;
   }
 }

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -29,6 +29,7 @@
       <% if can? :create, Project %>
         <li><%= link_to 'Project', projects_path, class: 'dropdown-item', method: :post %></li>
       <% end %>
+      <%= render partial: 'workspaces/new_modal', locals: { button_classes: 'dropdown-item' } %>
     <% end %>
 
     <% if new_content.present? %>

--- a/app/views/workspaces/_duplicate_modal.html.erb
+++ b/app/views/workspaces/_duplicate_modal.html.erb
@@ -1,7 +1,7 @@
       <% if can? :duplicate, workspace %>
         <%= button_tag 'Duplicate workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
-        <template>
-          <%= form_with(model: workspace, namespace: "duplicate", url: workspaces_path(template: workspace), method: :post, class: 'me-2 duplicate-workspace') do |form| %>
+        <template data-title="Duplicate workspace">
+          <%= form_with(model: workspace, namespace: "duplicate", url: workspaces_path(template: workspace), method: :post, class: 'me-2 workspace-form') do |form| %>
             <div class="modal-body">
               <p>Where do you want the duplicated workspace to be created?</p>
 

--- a/app/views/workspaces/_new_modal.html.erb
+++ b/app/views/workspaces/_new_modal.html.erb
@@ -1,16 +1,16 @@
-      <% if can? :update, workspace %>
-        <%= button_tag 'Move workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
-        <template data-title="Move workspace">
-          <%= form_with(model: workspace, namespace: 'move', class: 'me-2 workspace-form') do |form| %>
+      <% if can? :create, Workspace %>
+        <%= button_tag 'Workspace', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#workspaceModal', action: 'show-modal#copyFormTemplate' } %>
+        <template data-title="New workspace">
+          <%= form_with(model: Workspace.new(project: @project), namespace: "new", class: 'me-2 workspace-form') do |form| %>
             <div class="modal-body">
-              <p>Where do you want the workspace to be moved?</p>
+              <p>Where do you want the new workspace to be created?</p>
 
               <%= form.label :project_id, 'Select a project', class: 'mb-2 fw-bold' %>
               <%= form.collection_select :project_id, Project.accessible_by(current_ability, :update), :id, :title, {}, class: 'form-select' %>
             </div>
             <div class="modal-footer justify-content-end">
               <button type="button" class="btn btn-link" data-bs-dismiss="modal">Cancel</button>
-              <%= form.submit 'Move', class: 'btn btn-primary'%>
+              <%= form.submit 'Create', class: 'btn btn-primary'%>
             </div>
           <% end %>
         </template>


### PR DESCRIPTION
Fixes #136

In doing so, extend the pattern of workspace operation-specific modals established a few commits prior (perhaps getting closer to a refactoring to reduce duplication...) and collapse a few workspace form classes into a single one.

# Screencast

**NOTE**: There is a delay when the form is submitted because the webpack dev server is re-building the pack (due to CSS changes I made since the last time I loaded the page). We wouldn't see this in a deployed environment.

![Peek 2021-05-25 14-00](https://user-images.githubusercontent.com/131982/119568120-fe3fbf00-bd61-11eb-9068-bafb49c1b0a1.gif)

cc: @ggeisler 