### PR TITLE
Add a landing page for non-logged in users

### DIFF
--- a/app/assets/stylesheets/icons.css
+++ b/app/assets/stylesheets/icons.css
@@ -52,3 +52,36 @@
   width: 1rem;
   height: 1em;
 }
+
+.bi-collection-fill::before {
+  display: inline-block;
+  content: "";
+  vertical-align: -.66em;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-collection-fill" viewBox="0 0 16 16"><path d="M0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6v7zM2 3a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 0-1h-11A.5.5 0 0 0 2 3zm2-2a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 0-1h-7A.5.5 0 0 0 4 1z"/></svg>');
+  background-repeat: no-repeat;
+  background-size: 1.5rem 1.5rem;
+  width: 1.5rem;
+  height: 1.5em;
+}
+
+.bi-grid-1x2-fill::before {
+  display: inline-block;
+  content: "";
+  vertical-align: -.66em;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-grid-1x2-fill" viewBox="0 0 16 16"><path d="M0 1a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1zm9 0a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1V1zm0 9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1v-5z"/></svg>');
+  background-repeat: no-repeat;
+  background-size: 1.5rem 1.5rem;
+  width: 1.5rem;
+  height: 1.5em;
+}
+
+.bi-share-fill::before {
+  display: inline-block;
+  content: "";
+  vertical-align: -.66em;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-share-fill" viewBox="0 0 16 16"><path d="M11 2.5a2.5 2.5 0 1 1 .603 1.628l-6.718 3.12a2.499 2.499 0 0 1 0 1.504l6.718 3.12a2.5 2.5 0 1 1-.488.876l-6.718-3.12a2.5 2.5 0 1 1 0-3.256l6.718-3.12A2.5 2.5 0 0 1 11 2.5z"/></svg>');
+  background-repeat: no-repeat;
+  background-size: 1.5rem 1.5rem;
+  width: 1.5rem;
+  height: 1.5em;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,10 @@
 class HomeController < ApplicationController
   skip_authorization_check
 
+  def public
+    @featured_workspaces = Workspace.publicly_accessible.featured.order(updated_at: :desc).limit(3)
+  end
+
   def explore
     @updated_workspaces = Workspace.publicly_accessible.order(updated_at: :desc).limit(5)
     @featured_workspaces = Workspace.publicly_accessible.featured.order(updated_at: :desc).limit(5)

--- a/app/views/home/public.html.erb
+++ b/app/views/home/public.html.erb
@@ -1,0 +1,51 @@
+<div class="px-4 py-5 mb-4 text-center">
+  <h1 class="display-5 fw-bold">Mise</h1>
+  <div class="col-lg-6 mx-auto">
+    <p class="lead mb-4">An exploratory-stage application aimed at curators, students, and scholars, Mise provides a collaborative environment for annotation-oriented projects using the Mirador IIIF viewer.</p>
+    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
+      <%= link_to 'Sign up', new_user_registration_path, class: 'btn btn-primary btn-lg px-4 gap-3' %>
+      <%= link_to 'Log in', new_user_session_path, class: 'btn btn-outline-secondary btn-lg px-4' %>
+    </div>
+  </div>
+</div>
+
+<div class="container px-4 border-top">
+  <div class="row g-4 pt-5 pb-4 row-cols-1 row-cols-lg-3">
+    <div class="col d-flex align-items-start">
+      <div class="icon-square flex-shrink-0 me-3">
+        <i class="bi bi-collection-fill"></i>
+      </div>
+      <div>
+        <h2>Gather</h2>
+        <p>Mise users can gather IIIF resources and local images and add them to Mirador workspaces. Workspaces are organized into projects. Projects can be shared with other Mise users for collaborative work.</p>
+      </div>
+    </div>
+    <div class="col d-flex align-items-start">
+      <div class="icon-square flex-shrink-0 me-3">
+        <i class="bi bi-grid-1x2-fill"></i>
+      </div>
+      <div>
+        <h2>Arrange</h2>
+        <p>Mise users can leverage the feaures of the Mirador viewer and its plug-in ecosystem to arrange workspace windows, annotate resources, configure workspace options, and save their arrangements.</p>
+      </div>
+    </div>
+    <div class="col d-flex align-items-start">
+      <div class="icon-square flex-shrink-0 me-3">
+        <i class="bi bi-share-fill"></i>
+      </div>
+      <div>
+        <h2>Share</h2>
+        <p>Saved workspaces can be shared for duplication and collaboration within Mise, and for external publication purposes, as standalone or embeddable Mirador workspaces.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if @featured_workspaces.any? %>
+  <div class="container text-center pt-5 border-top">
+    <h2>Interested? Explore public workspaces from the Mise community</h2>
+      <div class="row workspace-cards g-4 mt-1 flex-wrap justify-content-around align-self-stretch">
+        <%= render collection: @featured_workspaces, partial: 'workspaces/card', as: :workspace %>
+      </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  root to: 'home#explore', as: :landing_page
+  root to: 'home#public', as: :landing_page
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
I'm creating this as a draft because:

- I want to get thoughts on whether this seems like reasonable content for a landing page a non-logged in user would see
- I touched a controller and routes and might not have done that part in the most ideal way (e.g. I named the new stuff `public`, which might not be ideal)
- There are a couple of unfinished loose ends

The goal for this is to provide a bit more of an informational landing page for non-logged in users. It's pretty basic now but we could obviously refine as Mise evolves. With this in place there will be some related things to think about, such as should a non-logged in user be able to see all of the Mise UI they currently see if they select a featured workspace? (I think it's helpful to let the non-logged in user see what a workspace is, etc., but there might be some things we want to hide from  them when they venture past the landing page.)

<img width="1264" alt="Screen Shot 2021-05-26 at 9 06 54 AM" src="https://user-images.githubusercontent.com/101482/119695623-3945ff00-be03-11eb-9ed8-011e86a6ddb0.png">

---

Things unfinished:

- [x] The `Sign up` button should link to the new user form but I'm not sure what the best way to do that is
- [ ] I think I'd like the gather, arrange, share icons to be more muted (e.g., `text-secondary` color?) but I cannot figure out how to change the color of the icons. The way of doing icons using the `icons.css` file is new to me and no matter where I try changing the color, I get no change.

To finish this up, I'm happy with any approach the developers want to  go with:

- Pair with me and tell me how to fix up the remaining stuff
- Someone can take over this branch and push up a more complete version
- Someone can just use this PR as a design suggestion and start a fresh PR and copy and paste stuff from here as is helpful