### PR TITLE
Remove last edited text from workspace card

### DIFF
--- a/app/views/workspaces/_card.html.erb
+++ b/app/views/workspaces/_card.html.erb
@@ -3,12 +3,11 @@
     <%= image_tag workspace.thumbnail.presence&.variant(resize_to_limit: [400, 400]) || 'placeholder.png', class: 'card-img-top', alt: ' ', aria: { hidden: true }, style: 'max-height: 200px' %>
   <% end %>
 
-  <div class="card-body d-flex flex-column">
-    <%= link_to workspace.title, workspace, class: 'card-title' %>
+  <div class="card-body d-flex flex-row pb-2">
+    <%= link_to workspace.title, workspace, class: 'card-title text-start flex-grow-1' %>
     <%= react_component 'Favorite', favorite: workspace.favorite, csrfToken: form_authenticity_token, updateUrl: workspace_path(workspace) %>
 
-    <div class="d-flex flex-grow-1 justify-content-between">
-      <p class="small-font-size">Last edited <%= time_ago_in_words(workspace.updated_at) %> ago</p>
+    <div class="d-flex align-self-start">
       <% options = capture do %>
         <% if can? :read, workspace %>
           <li><%= link_to 'Open workspace', viewer_workspace_path(workspace), class: 'dropdown-item', data: { turbolinks: false } %></li>
@@ -20,9 +19,9 @@
         <% end %>
       <% end %>
 
-      <div class="dropdown align-self-end ms-3">
+      <div class="dropdown ms-3">
         <% if options.present? %>
-          <a class="btn btn-outline-secondary" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+          <a class="btn btn-outline-light" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
             <span class="bi-three-dots"><span class="visually-hidden">Options</span></span>
           </a>
 


### PR DESCRIPTION
The "Last edited" text on the workspace card increases the height of the card and makes it generally less compact than it could be, arguably contributing to a somewhat disjoint arrangement of card elements. Since finding out when a workspace was last edited is still possible (from the workspace details page) and I'm guessing isn't something that is super important to know most of the time, this PR removes it from the workspace cards.

### Before - with the "Last edited" message

<img width="964" alt="Screen Shot 2021-05-27 at 10 49 35 AM" src="https://user-images.githubusercontent.com/101482/119873670-9f9d5100-bed9-11eb-845a-0924bd9f4561.png">

---

### After

<img width="964" alt="Screen Shot 2021-05-27 at 10 49 17 AM" src="https://user-images.githubusercontent.com/101482/119873727-af1c9a00-bed9-11eb-89d9-29c729baf420.png">
