### PR TITLE
Keeps Sidekiq on version 6 and Sidekiq pro on version 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,10 +103,10 @@ gem 'annotot', github: 'mejackreed/annotot'
 gem 'puppeteer-ruby'
 
 source 'https://gems.contribsys.com/' do
-  gem 'sidekiq-pro', group: :production
+  gem 'sidekiq-pro', '< 7', group: :production # Remain on v5 until Redis is updated to v7 on VMs
 end
 
-gem 'sidekiq'
+gem 'sidekiq', '< 7' # Remain on v6 until Redis is updated to v7 on VMs
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 GEM
   remote: https://gems.contribsys.com/
   specs:
-    sidekiq-pro (7.0.0)
-      sidekiq (>= 7.0.0, < 8)
+    sidekiq-pro (5.5.5)
+      sidekiq (~> 6.0, >= 6.5.6)
 
 GEM
   remote: https://rubygems.org/
@@ -403,11 +403,10 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    sidekiq (7.0.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -511,8 +510,8 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver
-  sidekiq
-  sidekiq-pro!
+  sidekiq (< 7)
+  sidekiq-pro (< 7)!
   sprockets-rails
   sqlite3 (~> 1.4)
   tophat
@@ -523,4 +522,4 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.20


### PR DESCRIPTION
This will unblock dependency updates and deploys until Redis is updated and we can update Sidekiq to version 7. See: https://github.com/sul-dlss/operations-tasks/issues/3210#issuecomment-1302508219