### PR TITLE
Unpin connection_pool gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,5 +109,3 @@ gem 'sidekiq', '~> 8.0'
 gem 'rack-protection', '< 3'
 
 gem 'cssbundling-rails', '~> 1.1'
-
-gem 'connection_pool', '~> 2.5' # pinned until fix for https://github.com/rails/rails/issues/56291 is released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     console (1.35.1)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -566,7 +566,6 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara (>= 3.26)
   config
-  connection_pool (~> 2.5)
   cssbundling-rails (~> 1.1)
   debug
   devise (~> 4.8)


### PR DESCRIPTION
The fix was included in Rails 8.1.2 so we can unpin this now: rails/rails#56292

Oh, but we also need this fixed in react-rails: https://github.com/reactjs/react-rails/issues/1366